### PR TITLE
Fix addons not expanding as normal

### DIFF
--- a/patcher.py
+++ b/patcher.py
@@ -1303,6 +1303,7 @@ def patch_overview():
                     };
                     
                     if (hasVisibleContent(child)) {
+                        child.classList.add('onigiri-external-overview-addon');
                         allExternalElements.push(child);
                         child.style.display = 'none'; // Hide initially
                     }

--- a/web/overview.css
+++ b/web/overview.css
@@ -17,6 +17,14 @@ body {
     padding: 0px 20px 20px 20px;
 }
 
+/* Ensure external overview add-ons can expand normally */
+.overview-center-container .onigiri-external-overview-addon {
+    align-self: stretch;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+
 /* New header for buttons */
 .overview-header {
     position: absolute;


### PR DESCRIPTION
Certain addons (in my case, [this](https://ankiweb.net/shared/info/1971437351)) currently fail to expand to their full width in the Onigiri-styled overview. This PR fixes that.

Disclaimer: The issue was fixed using LLM assistance. The change is, however, pretty trivial to review.

Also, thank you for this addon! Makes using Anki much more joyful.