### PR TITLE
Fixed Restaurant Widget

### DIFF
--- a/onigiri_renderer.py
+++ b/onigiri_renderer.py
@@ -535,10 +535,9 @@ def render_onigiri_deck_browser(self: DeckBrowser, reuse: bool = False) -> None:
             display: flex;
             flex-direction: row;
             background: var(--canvas-inset, #f5f5f5);
-            border-radius: 16px;
+            border-radius: 15px;
             overflow: hidden;
             height: 100%;
-            width: 95%;
             border: 1px solid var(--border, #e0e0e0);
             /* cursor: pointer; removed - only image is clickable */
             transition: all 0.3s ease;


### PR DESCRIPTION
# Description

I noticed the restaurant widget had a few problems (a missing right border, and the navigation button svgs were not centered inside of them), so I fixed that.

Before:
<img width="1068" height="722" alt="Screenshot 2026-01-25 at 3 36 02 AM" src="https://github.com/user-attachments/assets/1cf4493b-6400-4359-98a1-d28ef2b485b1" />

After:
<img width="1321" height="743" alt="image" src="https://github.com/user-attachments/assets/c951c707-c716-42f8-9bc6-ba7316708af6" />

# File Changes

## onigiri_renderer.py
### .onigiri-restaurant-level-widget
- Changed border-radius to 16px from 15px
- Changed width to 95% from 100%

### .rl-nav-icon
- Added a margin left of 4px