### PR TITLE
Fixes widget clipping issue

### DIFF
--- a/onigiri_renderer.py
+++ b/onigiri_renderer.py
@@ -520,6 +520,7 @@ def render_onigiri_deck_browser(self: DeckBrowser, reuse: bool = False) -> None:
             flex-direction: column;
             overflow: hidden;
             position: relative;
+            justify-content: center;
         }}
 
         /* Force the inner content (cards, heatmap, favorites) to fill the container */


### PR DESCRIPTION
Solves one of the issues with some external add-ons being clipped from the top. I tested it with only two add-ons to ensure it fixed the problem. It doesn't seem to have a significant impact on properly working external add-ons other than creating more space between widgets. Didn't affect built-in widgets at all when testing.
 

Complete (temp?) Fix:
#131 - Should be fully resolved now.


Partial Fix:
#8 - Unfortunately, doesn't fix every problem with this issue. Parts of some widgets are still completely missing, while others don't work at all. However, spacing did slightly improve usability for "problem add-ons."


Before example:
<img width="799" height="835" alt="image" src="https://github.com/user-attachments/assets/166b825f-4bb5-47c3-91d5-02c33757480f" />


After example:
<img width="888" height="911" alt="image" src="https://github.com/user-attachments/assets/7908202b-c4b8-40c0-b88c-cec059664e06" />


It took a lot of trial and error to see if anything would fix it and not make styling even worse. This was the best option I could find. All it does is add one "justify" line in "onigiri_renderer.py". That lets "div.external-widget-container" to center the add-on.

NOTE: Depending on how much of the add-on got clipped, more rows need to be given to the add-on in Widget Grid settings. if you give it 4 rows, it ends up treating all 4 rows as one block and centering between rows 2 and 3.