### PR TITLE
Improved Restaurant widget layout options

### DIFF
--- a/onigiri_renderer.py
+++ b/onigiri_renderer.py
@@ -340,7 +340,7 @@ def _get_onigiri_favorites_html() -> str:
         return "<div class='onigiri-favorites-widget'>Error loading favorites.</div>"
 # --- END OF NEW FUNCTION ---
 
-def _get_onigiri_restaurant_level_html() -> str:
+def _get_onigiri_restaurant_level_html(orientation: str = "horizontal") -> str:
     """
     Generates the HTML for the Restaurant Level widget.
     """
@@ -448,8 +448,9 @@ def _get_onigiri_restaurant_level_html() -> str:
     else:
         ds_html = "<div class='daily-special-section'><p class='ds-label'>No Daily Special Active</p></div>"
 
+    widget_orientation = "vertical" if orientation == "vertical" else "horizontal"
     return f"""
-    <div class="onigiri-restaurant-level-widget {snow_class}" style="--theme-bg: {bg_style_value}; --theme-color: {bar_color}">
+    <div class="onigiri-restaurant-level-widget orientation-{widget_orientation} {snow_class}" style="--theme-bg: {bg_style_value}; --theme-color: {bar_color}">
         <div class="restaurant-image-container" onclick="this.closest('.onigiri-restaurant-level-widget').classList.toggle('expanded-view'); event.stopPropagation();" style="cursor: pointer;">
             <img src="{image_path}" class="restaurant-image">
             {snowflakes_html}
@@ -520,19 +521,23 @@ def render_onigiri_deck_browser(self: DeckBrowser, reuse: bool = False) -> None:
         "retention": _get_onigiri_retention_html,
         "heatmap": _get_onigiri_heatmap_html,
         "favorites": _get_onigiri_favorites_html, # <-- ADD THIS LINE
-        "restaurant_level": _get_onigiri_restaurant_level_html,
     }
     
     if col_count > 0:
         for widget_id, widget_config in onigiri_layout.items():
-            if widget_id in widget_generators:
+            if widget_id in widget_generators or widget_id == "restaurant_level":
                 pos = widget_config.get("pos", 0)
                 row_span = widget_config.get("row", 1)
                 col_span = widget_config.get("col", 1)
                 row = pos // col_count + 1
                 col = pos % col_count + 1
                 style = f"grid-area: {row} / {col} / span {row_span} / span {col_span};"
-                onigiri_grid_html += f'<div class="onigiri-widget-container" style="{style}">{widget_generators[widget_id]()}</div>'
+                if widget_id == "restaurant_level":
+                    orientation = widget_config.get("orientation", "horizontal")
+                    widget_html = _get_onigiri_restaurant_level_html(orientation)
+                else:
+                    widget_html = widget_generators[widget_id]()
+                onigiri_grid_html += f'<div class="onigiri-widget-container" style="{style}">{widget_html}</div>'
 
     # --- Part 2: Build External Add-on Widgets (into the same unified grid) ---
     external_hooks = patcher._get_external_hooks()
@@ -627,6 +632,10 @@ def render_onigiri_deck_browser(self: DeckBrowser, reuse: bool = False) -> None:
             transition: all 0.3s ease;
             position: relative;
         }}
+
+        .onigiri-restaurant-level-widget.orientation-vertical {{
+            flex-direction: column;
+        }}
         
         .onigiri-restaurant-level-widget.expanded-view {{
             background: var(--theme-bg) !important;
@@ -652,6 +661,15 @@ def render_onigiri_deck_browser(self: DeckBrowser, reuse: bool = False) -> None:
             min-height: 0;
             overflow: hidden;
         }}
+
+        .onigiri-restaurant-level-widget.orientation-vertical .restaurant-image-container {{
+            flex: 0 0 auto;
+            width: 100%;
+            height: auto;
+            aspect-ratio: 1 / 1;
+            min-height: 0;
+            padding: 8px 10px 0 10px;
+        }}
         
         /* Unrestricted Sidebar resizing */
         .sidebar-left {{
@@ -660,7 +678,7 @@ def render_onigiri_deck_browser(self: DeckBrowser, reuse: bool = False) -> None:
 
         .main-content {{
             /* Dynamic Padding based on col_count */
-            padding: {40 if col_count == 4 else (20 if col_count > 4 else 60)}px !important;
+            padding: {24 if col_count == 4 else (14 if col_count > 4 else 32)}px !important;
             box-sizing: border-box !important;
             /* Sidebar Only Mode: Hide main content if cols=0 or rows=0 */
             display: {'none' if (col_count == 0 or conf.get('unifiedGridRows', 6) == 0) else 'flex'} !important;
@@ -676,7 +694,7 @@ def render_onigiri_deck_browser(self: DeckBrowser, reuse: bool = False) -> None:
         /* Allow grid to expand beyond 900px if we have many columns */
         .main-content > * {{
             width: 100%;
-            max-width: {1600 if col_count > 4 else 900}px !important;
+            max-width: {1400 if col_count > 4 else 820}px !important;
         }}
 
         .onigiri-restaurant-level-widget.expanded-view .restaurant-image-container {{
@@ -713,12 +731,18 @@ def render_onigiri_deck_browser(self: DeckBrowser, reuse: bool = False) -> None:
 
         .restaurant-info {{
             flex: 1;
+            min-width: 0;
             display: flex;
             flex-direction: column;
             justify-content: center;
             padding: 15px 20px;
             gap: 15px;
             transition: opacity 0.2s ease;
+        }}
+
+        .onigiri-restaurant-level-widget.orientation-vertical .restaurant-info {{
+            padding: 10px 16px 14px 16px;
+            gap: 10px;
         }}
         
         .onigiri-restaurant-level-widget.expanded-view .restaurant-info {{

--- a/settings.py
+++ b/settings.py
@@ -3461,6 +3461,7 @@ class SettingsDialog(QDialog):
             self.widget_id = widget_id
             self._col_span = 1
             self._row_span = 1
+            self.restaurant_orientation = "horizontal"
             self.display_name = text  # Store the display name
             self.grid_zone = None
             self.setObjectName("DraggableItem")
@@ -4217,6 +4218,7 @@ class SettingsDialog(QDialog):
 
             custom_menu = SettingsDialog.CustomMenu(self.window())
             is_heatmap = self.widget_id == 'heatmap'
+            is_restaurant = self.widget_id == 'restaurant_level'
 
             # --- Width Actions ---
             width_group = QButtonGroup(custom_menu)
@@ -4224,8 +4226,8 @@ class SettingsDialog(QDialog):
             max_cols = 4
             for i in range(1, max_cols + 1):
                 if is_heatmap and i < 2: continue # Heatmap min 2 cols
-                if self.widget_id == 'restaurant_level':
-                     if i != 2: continue # Restaurant Level exactly 2 cols
+                if is_restaurant:
+                     if i > 2: continue # Restaurant Level: allow 1 or 2 cols
                 btn = custom_menu.add_action_button(f"{i} Column{'s' if i > 1 else ''}", i, width_group, self.col_span == i)
 
             custom_menu.add_separator()
@@ -4234,11 +4236,11 @@ class SettingsDialog(QDialog):
             height_group = QButtonGroup(custom_menu)
             height_group.setExclusive(True)
             # Set row constraints
-            min_rows = 2 if (is_heatmap or self.widget_id == 'restaurant_level') else 1
+            min_rows = 2 if (is_heatmap or is_restaurant) else 1
             if is_heatmap:
                 max_rows = 2  # Heatmap: exactly 2 rows
-            elif self.widget_id == 'restaurant_level':
-                max_rows = 2  # Restaurant Level: exactly 2 rows (for now)
+            elif is_restaurant:
+                max_rows = 2  # Restaurant Level: exactly 2 rows
             elif self.widget_id == 'favorites':
                 max_rows = 3  # Favorites: up to 3 rows
             else:
@@ -4246,6 +4248,14 @@ class SettingsDialog(QDialog):
             for i in range(min_rows, max_rows + 1):
                 btn = custom_menu.add_action_button(f"{i} Row{'s' if i > 1 else ''}", i, height_group, self.row_span == i)
             
+            orientation_group = None
+            if is_restaurant:
+                custom_menu.add_separator()
+                orientation_group = QButtonGroup(custom_menu)
+                orientation_group.setExclusive(True)
+                custom_menu.add_action_button("Orientation: Side by Side", "horizontal", orientation_group, self.restaurant_orientation == "horizontal")
+                custom_menu.add_action_button("Orientation: Image on Top", "vertical", orientation_group, self.restaurant_orientation == "vertical")
+
             custom_menu.add_separator()
             
             # --- Archive Action ---
@@ -4257,13 +4267,19 @@ class SettingsDialog(QDialog):
             def on_menu_action():
                 new_col_span = width_group.checkedButton().property("action_data") if width_group.checkedButton() else self.col_span
                 new_row_span = height_group.checkedButton().property("action_data") if height_group.checkedButton() else self.row_span
+                new_orientation = self.restaurant_orientation
+                if orientation_group and orientation_group.checkedButton():
+                    new_orientation = orientation_group.checkedButton().property("action_data")
 
                 if new_col_span != self.col_span or new_row_span != self.row_span:
                     self.grid_zone.request_resize(self, new_row_span, new_col_span)
+                self.restaurant_orientation = new_orientation
                 custom_menu.close()
 
             width_group.buttonClicked.connect(on_menu_action)
             height_group.buttonClicked.connect(on_menu_action)
+            if orientation_group:
+                orientation_group.buttonClicked.connect(on_menu_action)
 
             custom_menu.move(self.mapToGlobal(event.pos()))
             custom_menu.show()
@@ -4912,6 +4928,8 @@ class SettingsDialog(QDialog):
                 if item := self.all_onigiri_items.get(widget_id):
                     item.row_span = config.get("row", 1)
                     item.col_span = config.get("col", 1)
+                    if widget_id == "restaurant_level":
+                        item.restaurant_orientation = config.get("orientation", "horizontal")
                     # Use a default 'pos' if missing (e.g., from old config)
                     if self.grid_zone.place_item(item, config.get("pos", 0), silent=True):
                         placed_widgets.add(widget_id)
@@ -4951,10 +4969,13 @@ class SettingsDialog(QDialog):
             for pos, shelf in self.grid_zone.shelves.items():
                 widget = shelf.child_widget
                 if widget and widget not in processed_widgets:
-                    grid_config[widget.widget_id] = {
+                    widget_config = {
                         "pos": pos, "row": widget.row_span, "col": widget.col_span,
                         "display_name": widget.display_name
                     }
+                    if widget.widget_id == "restaurant_level":
+                        widget_config["orientation"] = widget.restaurant_orientation
+                    grid_config[widget.widget_id] = widget_config
                     processed_widgets.add(widget)
 
             archive_config = self.archive_zone.get_archive_config()
@@ -5330,6 +5351,8 @@ class SettingsDialog(QDialog):
                 if item := self.all_onigiri_items.get(widget_id):
                     item.row_span = config.get("row", 1)
                     item.col_span = config.get("col", 1)
+                    if widget_id == "restaurant_level":
+                        item.restaurant_orientation = config.get("orientation", "horizontal")
                     if self.grid_zone.place_item(item, config.get("pos", 0), silent=True):
                         placed_onigiri.add(widget_id)
 
@@ -5456,10 +5479,13 @@ class SettingsDialog(QDialog):
                 if widget and widget not in processed_widgets:
                     # Check if it's an Onigiri widget
                     if isinstance(widget, SettingsDialog.OnigiriDraggableItem):
-                        onigiri_grid_config[widget.widget_id] = {
+                        widget_config = {
                             "pos": pos, "row": widget.row_span, "col": widget.col_span,
                             "display_name": widget.display_name
                         }
+                        if widget.widget_id == "restaurant_level":
+                            widget_config["orientation"] = widget.restaurant_orientation
+                        onigiri_grid_config[widget.widget_id] = widget_config
                     else:
                         # External widget
                         external_grid_config[widget.widget_id] = {
@@ -5551,6 +5577,8 @@ class SettingsDialog(QDialog):
                 if item := self.all_onigiri_items.get(widget_id):
                     item.row_span = config.get("row", 1)
                     item.col_span = config.get("col", 1)
+                    if widget_id == "restaurant_level":
+                        item.restaurant_orientation = "horizontal"
                     
                     # Ensure item is clean
                     item.grid_zone = None


### PR DESCRIPTION

Resolved #210 
Added a new Restaurant Level Orientation option so you can switch between side-by-side and image-on-top layouts.
Added support for resizing Restaurant Level to 1x2, instead of the default 2x2.
Improved the image/layout behavior so square-image logic applies while in vertical mode.
Tightened the main menu widget-area boundaries (smaller padding and max width) to allow the layout to feel more compact.

<img width="1720" height="873" alt="image" src="https://github.com/user-attachments/assets/9300369b-f2b1-4459-b387-9d2248e802e1" />
