### PR TITLE
fix: clean up __init__.py imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,7 +8,6 @@ from aqt.overview import Overview
 from aqt.toolbar import Toolbar, BottomBar
 from aqt.qt import QWidget, QHBoxLayout, QPushButton, Qt, QToolBar, QAction, QTimer
 from . import patcher
-from . import settings
 from . import config
 from . import menu_buttons
 from .gamification import mochi_messages
@@ -20,7 +19,7 @@ from .gamification import focus_dango
 from . import birthday_dialog
 from . import icon_chooser
 from . import heatmap
-from .sidebar_api import register_sidebar_action
+from . import sidebar_api
 from .sync import onigiri_sync
 from .sync_ui import show_sync_conflict_dialog
 
@@ -325,7 +324,6 @@ def setup_global_hooks():
     menu_buttons.setup_onigiri_menu(addon_path)
     
     # Install the toolbar bridge AFTER other addons have loaded their hooks
-    from . import sidebar_api
     sidebar_api.ensure_capture_hook_is_last()
 
 def on_profile_did_open():


### PR DESCRIPTION
## Summary
- Removes unused `from . import settings` import
- Replaces unused `from .sidebar_api import register_sidebar_action` with `from . import sidebar_api` (the module itself is needed at two call sites)
- Removes redundant deferred import inside `setup_global_hooks()`

## Why
`sidebar_api.ensure_capture_hook_is_last()` was called in `on_profile_did_open()` without `sidebar_api` being in scope — it relied on a deferred import in a *different function* (`setup_global_hooks`) having already run. This worked at runtime by accident but would break if call order ever changed. Now it's a proper module-level import.

## How to test
1. Load the add-on in Anki
2. Verify sidebar renders correctly
3. Verify no import errors in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)