### PR TITLE
Add Special Days engine with party-mode easter eggs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ user_files/settings_*
 user_files/icons/*
 meta.json
 system_files/.DS_Store
+.pytest_cache/
+.venv/

--- a/__init__.py
+++ b/__init__.py
@@ -20,6 +20,7 @@ from . import deck_tree_updater
 from . import webview_handlers
 from .gamification import focus_dango
 from . import birthday_dialog
+from . import special_days
 from . import heatmap
 from . import sidebar_api
 from .sync import onigiri_sync
@@ -149,7 +150,25 @@ def inject_menu_files(web_content, context):
                 """
             except Exception:
                 pass
-        
+
+        # --- Special Days / Party Mode ---
+        # get_party_state() is cached (built once at profile open), so this adds
+        # no per-render SQL. Assets + the festive accent override are injected
+        # ONLY on a special day; on any normal render nothing here runs, so the
+        # accent auto-reverts to the user's saved theme.
+        try:
+            special_days_conf = conf.get("special_days", {})
+            if special_days_conf.get("enabled", True):
+                party = special_days.get_party_state()
+                if party:
+                    web_content.head += f"<script>window.ONIGIRI_PARTY_MODE = {json.dumps(party)};</script>"
+                    web_content.head += f'<link rel="stylesheet" href="{web_assets_root}/party.css">'
+                    web_content.head += f'<script src="{web_assets_root}/party.js"></script>'
+                    if special_days_conf.get("festive_accent", False):
+                        web_content.head += special_days.generate_party_accent_css(party.get("accent", "#FFD700"))
+        except Exception:
+            pass
+
     elif is_reviewer:
         silent_notifs = "true" if conf.get("onigiri_reviewer_silent_notifications", False) else "false"
         web_content.head += f'<script>window.onigiriSilentNotifications = {silent_notifs};</script>'
@@ -385,9 +404,14 @@ def on_profile_did_open():
     if onigiri_sync.is_enabled():
         QTimer.singleShot(1000, on_sync_did_finish)
 
-    # Show birthday popup if it's the user's birthday (requires mw.col)
-    # Delay by 1s to ensure main window is fully rendered for screenshot blur
-    QTimer.singleShot(1000, lambda: birthday_dialog.maybe_show_birthday_popup())
+    # Special days: birthday, study anniversary, New Year, review milestones.
+    # Warm the once-per-open cache now (two cheap revlog scalars) so later
+    # render-time party-mode checks are pure dict access. Then run the one-shot
+    # celebration path after 1s so the main window is fully rendered (the
+    # birthday modal blurs a screenshot of it).
+    special_days.invalidate_cache()
+    special_days.get_context()
+    QTimer.singleShot(1000, special_days.check_and_celebrate)
 
     # Menu styling disabled per user request
     # patcher.apply_menu_styling()
@@ -491,6 +515,8 @@ def on_deck_options_shown(menu, deck_id):
 # Hook Registration
 gui_hooks.main_window_did_init.append(setup_global_hooks)
 gui_hooks.profile_did_open.append(on_profile_did_open)
+# Drop the special-days cache when switching profiles so the next profile recomputes.
+gui_hooks.profile_will_close.append(special_days.invalidate_cache)
 gui_hooks.webview_will_set_content.append(inject_menu_files)
 gui_hooks.deck_browser_did_render.append(on_deck_browser_did_render)
 gui_hooks.webview_did_receive_js_message.append(patcher.on_webview_js_message)

--- a/config.py
+++ b/config.py
@@ -33,7 +33,25 @@ DEFAULTS = {
     "congratsMessage": "Congratulations! You have finished this deck for now.",
     "showWelcomePopup": True,
     "userBirthday": "",  # Format: YYYY-MM-DD, empty = not set
-    "lastBirthdayShown": "",  # Year when birthday popup was last shown 
+    "lastBirthdayShown": "",  # Year when birthday popup was last shown
+    # --- Special Days / Party Mode ---
+    # Generalizes the birthday popup into a multi-occasion engine (birthday,
+    # study anniversary, New Year, lifetime review milestones) plus "party mode"
+    # visuals. See special_days.py.
+    "special_days": {
+        "enabled": True,          # Master toggle for detection + party visuals
+        "confetti": True,         # All-day confetti drift on the deck browser
+        "festive_accent": False,  # Temporarily recolor the accent (opt-in: changes the user's theme color)
+        "heatmap_effect": True,   # Festive glow + emoji on today's heatmap cell
+        # Per-occasion "already celebrated" guards.
+        # Year-string for date occasions; highest int milestone celebrated.
+        "last_shown": {
+            "birthday": "",
+            "study_anniversary": "",
+            "new_year": "",
+            "review_milestone": 0,
+        },
+    },
     "hideRetentionStars": False,
     "showHeatmapOnProfile": True,
     "achievements": {
@@ -478,6 +496,14 @@ def get_config():
     if "showHeatmapOnProfile" not in user_config:
          if mw.col and "onigiri_profile_show_stats" in mw.col.conf:
             clean_config["showHeatmapOnProfile"] = mw.col.conf.get("onigiri_profile_show_stats", True)
+
+    # Compatibility: fold the legacy top-level lastBirthdayShown guard into the
+    # new special_days.last_shown.birthday slot (preserve "already shown this year").
+    special_days_conf = clean_config.setdefault("special_days", copy.deepcopy(DEFAULTS["special_days"]))
+    last_shown_conf = special_days_conf.setdefault("last_shown", {})
+    legacy_birthday_shown = clean_config.get("lastBirthdayShown", "")
+    if legacy_birthday_shown and not last_shown_conf.get("birthday"):
+        last_shown_conf["birthday"] = legacy_birthday_shown
         
     # Compatibility: Migrate restaurant_level and daily_special from achievements to top-level
     if "achievements" in clean_config:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py

--- a/settings.py
+++ b/settings.py
@@ -31,6 +31,7 @@ from aqt import mw, gui_hooks
 from aqt.theme import theme_manager
 from typing import Union
 from . import config
+from . import special_days
 from .config import DEFAULTS
 from .constants import COLOR_LABELS, ICON_DEFAULTS, DEFAULT_ICON_SIZES, ALL_THEME_KEYS, REVIEWER_THEME_KEYS
 from .themes import THEMES 
@@ -8531,6 +8532,34 @@ class SettingsDialog(QDialog):
         details_section.add_layout(form_layout)
         layout.addWidget(details_section)
 
+        # --- Special Days & Party Mode ---
+        special_days_conf = self.current_config.get("special_days", {})
+        sd_section = SectionGroup(
+            tr("special_days_section", "Special Days & Party Mode"),
+            self,
+            description=tr(
+                "special_days_desc",
+                "Celebrate your birthday, study anniversary, New Year, and lifetime review milestones with confetti and festive touches.",
+            ),
+        )
+        self.special_days_enabled_check = AnimatedToggleButton(accent_color=self.accent_color)
+        self.special_days_enabled_check.setChecked(bool(special_days_conf.get("enabled", True)))
+        sd_section.add_widget(self._create_toggle_row(self.special_days_enabled_check, tr("special_days_enable", "Enable special days & party mode")))
+
+        self.party_confetti_check = AnimatedToggleButton(accent_color=self.accent_color)
+        self.party_confetti_check.setChecked(bool(special_days_conf.get("confetti", True)))
+        sd_section.add_widget(self._create_toggle_row(self.party_confetti_check, tr("party_confetti", "All-day confetti")))
+
+        self.party_heatmap_check = AnimatedToggleButton(accent_color=self.accent_color)
+        self.party_heatmap_check.setChecked(bool(special_days_conf.get("heatmap_effect", True)))
+        sd_section.add_widget(self._create_toggle_row(self.party_heatmap_check, tr("party_heatmap", "Festive heatmap effect")))
+
+        self.party_accent_check = AnimatedToggleButton(accent_color=self.accent_color)
+        self.party_accent_check.setChecked(bool(special_days_conf.get("festive_accent", False)))
+        sd_section.add_widget(self._create_toggle_row(self.party_accent_check, tr("party_accent", "Festive accent color for the day")))
+
+        layout.addWidget(sd_section)
+
         pic_section = SectionGroup(tr("profile_picture"), self)
         self.galleries["profile_pic"] = {} 
         profile_pic_gallery = self._create_image_gallery_group(
@@ -8642,6 +8671,7 @@ class SettingsDialog(QDialog):
         layout.addStretch()
         sections = {
             tr("user_details"): details_section,
+            tr("special_days_section", "Special Days & Party Mode"): sd_section,
             tr("profile_picture"): pic_section,
             tr("profile_bar_background"): bg_section,
             tr("profile_page_background"): page_bg_section,
@@ -12769,6 +12799,19 @@ class SettingsDialog(QDialog):
                  self.current_config["userBirthday"] = birthday_date.toString("yyyy-MM-dd")
             else:
                  self.current_config["userBirthday"] = ""
+
+        # Save Special Days / Party Mode toggles
+        if hasattr(self, 'special_days_enabled_check'):
+            sd = self.current_config.setdefault("special_days", {})
+            sd["enabled"] = self.special_days_enabled_check.isChecked()
+            sd["confetti"] = self.party_confetti_check.isChecked()
+            sd["heatmap_effect"] = self.party_heatmap_check.isChecked()
+            sd["festive_accent"] = self.party_accent_check.isChecked()
+            # Recompute party state on the next render so toggles apply immediately.
+            try:
+                special_days.invalidate_cache()
+            except Exception:
+                pass
 
         if 'profile_pic' in self.galleries:
             mw.col.conf["modern_menu_profile_picture"] = self.galleries['profile_pic']['selected']

--- a/special_days.py
+++ b/special_days.py
@@ -1,0 +1,373 @@
+"""
+Special Days engine for Onigiri.
+
+Generalizes the original birthday popup into a small, reusable engine that
+detects several "occasions" (birthday, study anniversary, New Year, lifetime
+review milestones) and drives two independent kinds of celebration:
+
+  1. ONE-SHOT notifications (the big birthday modal, or a toast) — fired once
+     per occasion via a per-occasion guard stored in config.
+  2. ALL-DAY "party mode" visuals (confetti drift, festive glow + emoji on
+     today's heatmap cell, optional festive accent override) — injected on
+     every deck-browser render while the occasion is active.
+
+Performance note: the only cost is two cheap aggregate scalars on `revlog`,
+run ONCE per profile open and cached (see `build_context`/`get_context`).
+`get_party_state()` — called during every webview render in
+`inject_menu_files()` — is pure cached-dict access and runs no SQL.
+"""
+
+import calendar
+from datetime import datetime
+
+from aqt import mw
+
+from . import config
+from . import birthday_dialog
+from . import onigiri_notifications
+from .translations import tr
+
+
+# Lifetime-review thresholds that earn a celebration, ascending.
+MILESTONE_THRESHOLDS = [10000, 25000, 50000, 100000, 250000, 500000, 1000000]
+
+# Primary occasion wins the emoji/accent when several are active on one day.
+_PRIMARY_PRIORITY = ["birthday", "review_milestone", "study_anniversary", "new_year"]
+
+# Developer affordance: put occasion ids in here to force them active today
+# (bypasses date/threshold detection) so the full inject + visual + toast path
+# can be exercised without waiting for a real date. MUST be empty for release.
+DEBUG_FORCE = set()
+
+
+def _date_matches_today(month, day, today):
+    """True if (month, day) is today, treating Feb-29 as Feb-28 in non-leap years."""
+    if month == 2 and day == 29 and not calendar.isleap(today.year):
+        month, day = 2, 28
+    return today.month == month and today.day == day
+
+
+class _DayContext:
+    """Precomputed facts for "today", shared by every occasion's detect()."""
+
+    def __init__(self, today, year_str, total_reviews, first_review_date, conf, sd_conf):
+        self.today = today
+        self.year_str = year_str
+        self.total_reviews = total_reviews
+        self.first_review_date = first_review_date
+        self.conf = conf
+        self.sd_conf = sd_conf
+        self.active = []          # list of (Occasion, match dict)
+        self.party_payload = None  # dict for party.js / accent CSS, or None
+
+
+class Occasion:
+    """Base occasion. Subclasses override detect() and the celebration bits."""
+
+    id = ""
+    uses_modal = False   # True -> celebrate() shows the big modal instead of a toast
+    emoji = "🎉"
+    accent = "#FFD700"   # festive accent used when this occasion is primary
+
+    def detect(self, ctx):
+        """Return a truthy "match" dict if active today, else None."""
+        raise NotImplementedError
+
+    def debug_match(self, ctx):
+        """A plausible synthetic match used by DEBUG_FORCE."""
+        return {"debug": True}
+
+    # --- one-shot guard (default: once per calendar year) ---
+    def already_fired(self, guard_val, match, ctx):
+        return guard_val == ctx.year_str
+
+    def new_guard_value(self, match, ctx):
+        return ctx.year_str
+
+    # --- celebration ---
+    def celebrate(self, match, ctx):
+        title, desc = self.toast_text(match, ctx)
+        onigiri_notifications.notify(
+            desc,
+            title=title,
+            icon=self.emoji,
+            duration=7000,
+            centered=True,
+        )
+
+    def toast_text(self, match, ctx):
+        return ("Onigiri", "")
+
+
+class BirthdayOccasion(Occasion):
+    id = "birthday"
+    uses_modal = True
+    emoji = "🎂"
+    accent = "#FF5FA2"
+
+    def detect(self, ctx):
+        birthday_str = ctx.conf.get("userBirthday", "")
+        if not birthday_str:
+            return None
+        try:
+            bdate = datetime.strptime(birthday_str, "%Y-%m-%d").date()
+        except ValueError:
+            return None
+        if not _date_matches_today(bdate.month, bdate.day, ctx.today):
+            return None
+        return {"age": ctx.today.year - bdate.year}
+
+    def debug_match(self, ctx):
+        return {"age": 25}
+
+    def celebrate(self, match, ctx):
+        user_name = ctx.conf.get("userName", "User")
+        birthday_dialog.show_birthday_dialog(user_name, match.get("age", 0))
+
+
+class StudyAnniversaryOccasion(Occasion):
+    id = "study_anniversary"
+    emoji = "🎓"
+    accent = "#5FC9FF"
+
+    def detect(self, ctx):
+        first = ctx.first_review_date
+        if not first:
+            return None
+        if not _date_matches_today(first.month, first.day, ctx.today):
+            return None
+        years = ctx.today.year - first.year
+        if years < 1:
+            return None
+        return {"years": years}
+
+    def debug_match(self, ctx):
+        return {"years": 3}
+
+    def toast_text(self, match, ctx):
+        years = match.get("years", 1)
+        title = tr("anniversary_toast_title", "🎓 Study Anniversary!")
+        desc = tr(
+            "anniversary_toast_desc",
+            "{years} years since your very first review. Look how far you've come!",
+        ).format(years=years)
+        return (title, desc)
+
+
+class NewYearOccasion(Occasion):
+    id = "new_year"
+    emoji = "🎉"
+    accent = "#FFD700"
+
+    def detect(self, ctx):
+        if ctx.today.month == 1 and ctx.today.day == 1:
+            return {"year": ctx.today.year}
+        return None
+
+    def debug_match(self, ctx):
+        return {"year": ctx.today.year}
+
+    def toast_text(self, match, ctx):
+        year = match.get("year", ctx.today.year)
+        title = tr("new_year_toast_title", "🎉 Happy New Year!")
+        desc = tr(
+            "new_year_toast_desc",
+            "Welcome to {year} — a fresh year of learning awaits!",
+        ).format(year=year)
+        return (title, desc)
+
+
+class ReviewMilestoneOccasion(Occasion):
+    id = "review_milestone"
+    emoji = "🏆"
+    accent = "#FFB000"
+
+    def _last_celebrated(self, ctx):
+        try:
+            return int(ctx.sd_conf.get("last_shown", {}).get("review_milestone", 0) or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    def detect(self, ctx):
+        crossed = [t for t in MILESTONE_THRESHOLDS if t <= ctx.total_reviews]
+        if not crossed:
+            return None
+        highest = max(crossed)
+        # Unlike date occasions, a milestone has no natural day boundary, so the
+        # guard is consulted here: it stays active only until celebrated.
+        if highest <= self._last_celebrated(ctx):
+            return None
+        return {"milestone": highest}
+
+    def debug_match(self, ctx):
+        return {"milestone": 10000}
+
+    def already_fired(self, guard_val, match, ctx):
+        try:
+            last = int(guard_val or 0)
+        except (TypeError, ValueError):
+            last = 0
+        return last >= match.get("milestone", 0)
+
+    def new_guard_value(self, match, ctx):
+        return match.get("milestone", 0)
+
+    def toast_text(self, match, ctx):
+        count = match.get("milestone", 0)
+        title = tr("milestone_toast_title", "🏆 Milestone reached!")
+        desc = tr(
+            "milestone_toast_desc",
+            "{count} lifetime reviews — incredible dedication!",
+        ).format(count=f"{count:,}")
+        return (title, desc)
+
+
+REGISTRY = [
+    BirthdayOccasion(),
+    StudyAnniversaryOccasion(),
+    NewYearOccasion(),
+    ReviewMilestoneOccasion(),
+]
+
+_OCCASIONS_BY_ID = {occ.id: occ for occ in REGISTRY}
+
+
+def _build_party_payload(active, sd_conf):
+    """Merge the active occasions into one descriptor for party.js + accent CSS."""
+    if not active:
+        return None
+    active_by_id = {occ.id: occ for occ, _ in active}
+    primary_id = next((pid for pid in _PRIMARY_PRIORITY if pid in active_by_id), None)
+    primary = active_by_id.get(primary_id) or active[0][0]
+    return {
+        "occasions": [occ.id for occ, _ in active],
+        "emoji": primary.emoji,
+        "accent": primary.accent,
+        "confetti": bool(sd_conf.get("confetti", True)),
+        "heatmap_effect": bool(sd_conf.get("heatmap_effect", True)),
+    }
+
+
+# --- Per-profile-open cache ----------------------------------------------------
+_CACHE = None
+_CACHE_DAY = None
+
+
+def build_context():
+    """Compute today's occasions. Runs the two revlog scalars (once per open)."""
+    conf = config.get_config()
+    sd_conf = conf.get("special_days", {})
+    today = datetime.now().date()
+
+    total_reviews = 0
+    first_review_date = None
+    try:
+        if mw.col:
+            total_reviews = mw.col.db.scalar(
+                "SELECT COUNT() FROM revlog WHERE type IN (0,1,2,3)"
+            ) or 0
+            first_ts = mw.col.db.scalar(
+                "SELECT min(id) FROM revlog WHERE type IN (0,1,2,3)"
+            )
+            if first_ts:
+                first_review_date = datetime.fromtimestamp(first_ts / 1000).date()
+    except Exception as exc:
+        print(f"Onigiri special_days: could not read revlog stats: {exc}")
+
+    ctx = _DayContext(today, str(today.year), total_reviews, first_review_date, conf, sd_conf)
+
+    if sd_conf.get("enabled", True):
+        for occ in REGISTRY:
+            try:
+                match = occ.detect(ctx)
+            except Exception as exc:
+                print(f"Onigiri special_days: detect({occ.id}) failed: {exc}")
+                match = None
+            if match is None and occ.id in DEBUG_FORCE:
+                match = occ.debug_match(ctx)
+            if match is not None:
+                ctx.active.append((occ, match))
+
+    ctx.party_payload = _build_party_payload(ctx.active, sd_conf)
+    return ctx
+
+
+def get_context():
+    """Cached context, rebuilt on first use, profile open, or date rollover."""
+    global _CACHE, _CACHE_DAY
+    today = datetime.now().date()
+    if _CACHE is None or _CACHE_DAY != today:
+        _CACHE = build_context()
+        _CACHE_DAY = today
+    return _CACHE
+
+
+def invalidate_cache():
+    """Drop the cache (call on profile close or after settings change)."""
+    global _CACHE, _CACHE_DAY
+    _CACHE = None
+    _CACHE_DAY = None
+
+
+# --- Public API ----------------------------------------------------------------
+def get_party_state():
+    """Cheap accessor for inject_menu_files(): the merged party payload, or None.
+
+    After the first build (profile open) this is pure dict access — no SQL.
+    """
+    conf = config.get_config()
+    if not conf.get("special_days", {}).get("enabled", True):
+        return None
+    try:
+        return get_context().party_payload
+    except Exception as exc:
+        print(f"Onigiri special_days: get_party_state failed: {exc}")
+        return None
+
+
+def generate_party_accent_css(accent):
+    """A standalone, high-specificity accent override.
+
+    It auto-reverts simply by NOT being injected on the next non-special render,
+    so the user's saved theme in config is never mutated.
+    """
+    return (
+        '<style id="onigiri-party-mode-override">'
+        f":root {{ --accent-color: {accent} !important; --button-primary-bg: {accent} !important; }}"
+        f".night-mode {{ --accent-color: {accent} !important; --button-primary-bg: {accent} !important; }}"
+        "</style>"
+    )
+
+
+def check_and_celebrate():
+    """One-shot path (run on a QTimer after profile open).
+
+    Fires each active occasion's modal/toast at most once per guard, then
+    persists the updated guards in a single config write.
+    """
+    conf = config.get_config()
+    if not conf.get("special_days", {}).get("enabled", True):
+        return
+
+    ctx = get_context()
+    if not ctx.active:
+        return
+
+    special_days_conf = conf.setdefault("special_days", {})
+    last_shown = special_days_conf.setdefault("last_shown", {})
+
+    changed = False
+    for occ, match in ctx.active:
+        guard_val = last_shown.get(occ.id)
+        if occ.already_fired(guard_val, match, ctx):
+            continue
+        try:
+            occ.celebrate(match, ctx)
+        except Exception as exc:
+            print(f"Onigiri special_days: celebrate({occ.id}) failed: {exc}")
+            continue
+        last_shown[occ.id] = occ.new_guard_value(match, ctx)
+        changed = True
+
+    if changed:
+        config.write_config(conf)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+"""
+Test bootstrap that lets pure Onigiri logic be imported and unit-tested
+*without* a running Anki (no `aqt`, no Qt, no display).
+
+The only thing that stops `special_days.py` from importing outside Anki is its
+module-level `from aqt import mw` plus its relative imports of sibling modules
+that do the same. We don't need any of that machinery to exercise the engine's
+pure logic (date math, occasion detection, guards, payload merging), so here we:
+
+  1. stub the one Anki symbol it imports at load time (`aqt.mw`);
+  2. register `onigiri` as a package *without* running its heavy __init__.py; and
+  3. fake the sibling modules it imports, so `special_days` loads in isolation.
+
+This is the reusable "Tier 1" harness: any future pure-logic module can be
+tested the same way. Anything that genuinely needs the collection (revlog
+queries) or the GUI belongs in a separate Tier 2/Tier 3 suite, not here.
+"""
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+# 1. Stub the single Anki symbol special_days imports at module load time.
+#    A MagicMock tolerates any attribute/call chain (mw.col.db.scalar(...)),
+#    which is all we need for *import* to succeed.
+_aqt = types.ModuleType("aqt")
+_aqt.mw = MagicMock()
+sys.modules.setdefault("aqt", _aqt)
+
+# 2. Register `onigiri` as a package pointing at the repo dir, but DON'T execute
+#    the real (heavy, Anki-coupled) __init__.py. Because the name is now present
+#    in sys.modules, `import onigiri.special_days` finds special_days.py via this
+#    __path__ and never re-imports the package init.
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_pkg = types.ModuleType("onigiri")
+_pkg.__path__ = [_REPO]
+sys.modules["onigiri"] = _pkg
+
+
+def _fake_module(name, **attrs):
+    """Register a stand-in for one of special_days' sibling modules."""
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    sys.modules[name] = mod
+    return mod
+
+
+# 3. Fake the siblings special_days imports. These are faithful to the call
+#    signatures special_days uses, but do nothing (or echo a default) — the
+#    pure logic under test never depends on their real behaviour.
+_fake_module("onigiri.config", get_config=lambda: {}, write_config=lambda conf: None)
+_fake_module("onigiri.translations", tr=lambda key, default="", *a, **k: default)
+_fake_module("onigiri.onigiri_notifications", notify=lambda *a, **k: None)
+_fake_module("onigiri.birthday_dialog", show_birthday_dialog=lambda *a, **k: None)

--- a/tests/run.py
+++ b/tests/run.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Zero-dependency runner for Onigiri's Tier 1 suite.
+
+This box has no pip/pytest (Python is externally managed), so this runner lets
+the pure-logic tests run with nothing but the system Python. It applies the same
+tests/conftest.py stubs that pytest would, and the suite stays fully
+pytest-compatible: anywhere pytest *is* available (e.g. CI), plain `pytest` runs
+the identical tests with no changes.
+
+    python3 tests/run.py
+"""
+
+import importlib
+import os
+import sys
+import traceback
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+# Side effects only: stub `aqt` and fake the `onigiri` siblings before any test
+# module imports the engine. This is exactly what pytest loads from conftest.py.
+import conftest  # noqa: F401,E402
+
+TEST_MODULES = ["test_special_days"]
+
+
+def main():
+    passed, failures = 0, []
+    for mod_name in TEST_MODULES:
+        module = importlib.import_module(mod_name)
+        tests = [
+            (name, obj)
+            for name, obj in vars(module).items()
+            if name.startswith("test_") and callable(obj)
+        ]
+        for name, fn in tests:
+            try:
+                fn()
+            except Exception:  # AssertionError or anything else == failure
+                failures.append((f"{mod_name}::{name}", traceback.format_exc()))
+                sys.stdout.write("F")
+            else:
+                passed += 1
+                sys.stdout.write(".")
+            sys.stdout.flush()
+
+    print("\n")
+    for label, tb in failures:
+        print(f"FAILED {label}\n{tb}")
+    total = passed + len(failures)
+    print(f"{passed}/{total} passed, {len(failures)} failed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_special_days.py
+++ b/tests/test_special_days.py
@@ -1,0 +1,203 @@
+"""
+Tier 1 unit tests for the Special Days engine — pure logic only, no Anki.
+
+These cover the parts where the bugs actually live: the Feb-29 leap-year fix,
+the "celebrate a milestone exactly once" guard, occasion detection, and the
+party-payload priority merge. Every test builds a plain _DayContext by hand and
+calls the engine directly, so the whole suite runs in milliseconds with no
+collection, no Qt and no display.
+"""
+
+from datetime import date
+
+from onigiri import special_days as sd
+
+
+def make_ctx(today, *, total_reviews=0, first_review_date=None, conf=None, sd_conf=None):
+    """Build a _DayContext the way build_context() would, but from plain data."""
+    conf = conf or {}
+    if sd_conf is None:
+        sd_conf = conf.get("special_days", {})
+    return sd._DayContext(
+        today=today,
+        year_str=str(today.year),
+        total_reviews=total_reviews,
+        first_review_date=first_review_date,
+        conf=conf,
+        sd_conf=sd_conf,
+    )
+
+
+# Occasions are stateless, so a single shared instance per type is fine.
+BIRTHDAY = sd.BirthdayOccasion()
+ANNIVERSARY = sd.StudyAnniversaryOccasion()
+NEW_YEAR = sd.NewYearOccasion()
+MILESTONE = sd.ReviewMilestoneOccasion()
+
+
+# --- _date_matches_today: the headline Feb-29 leap-year fix -------------------
+
+def test_date_matches_exact_day():
+    assert sd._date_matches_today(6, 23, date(2026, 6, 23)) is True
+
+
+def test_date_does_not_match_other_day():
+    assert sd._date_matches_today(6, 23, date(2026, 6, 24)) is False
+
+
+def test_feb29_celebrated_on_feb28_in_non_leap_year():
+    # 2027 is not a leap year -> a Feb-29 occasion should fall back to Feb-28.
+    assert sd._date_matches_today(2, 29, date(2027, 2, 28)) is True
+
+
+def test_feb29_not_matched_on_feb27_in_non_leap_year():
+    assert sd._date_matches_today(2, 29, date(2027, 2, 27)) is False
+
+
+def test_feb29_matches_real_feb29_in_leap_year():
+    # 2028 *is* a leap year -> the real Feb-29 still matches.
+    assert sd._date_matches_today(2, 29, date(2028, 2, 29)) is True
+
+
+def test_feb29_not_remapped_in_leap_year():
+    # In a leap year there is no fallback, so Feb-28 must not match Feb-29.
+    assert sd._date_matches_today(2, 29, date(2028, 2, 28)) is False
+
+
+# --- BirthdayOccasion.detect --------------------------------------------------
+
+def test_birthday_today_returns_age():
+    ctx = make_ctx(date(2026, 6, 23), conf={"userBirthday": "2000-06-23"})
+    assert BIRTHDAY.detect(ctx) == {"age": 26}
+
+
+def test_birthday_absent_returns_none():
+    assert BIRTHDAY.detect(make_ctx(date(2026, 6, 23), conf={})) is None
+
+
+def test_birthday_malformed_returns_none():
+    ctx = make_ctx(date(2026, 6, 23), conf={"userBirthday": "nonsense"})
+    assert BIRTHDAY.detect(ctx) is None
+
+
+def test_birthday_feb29_fires_on_feb28_in_non_leap_year():
+    # The regression the commit fixed: Feb-29 birthdays were missed in 2027.
+    ctx = make_ctx(date(2027, 2, 28), conf={"userBirthday": "2000-02-29"})
+    assert BIRTHDAY.detect(ctx) == {"age": 27}
+
+
+# --- ReviewMilestoneOccasion: detection + "celebrate exactly once" guard ------
+
+def test_milestone_detects_highest_threshold_crossed():
+    ctx = make_ctx(date(2026, 6, 23), total_reviews=30000, sd_conf={"last_shown": {}})
+    assert MILESTONE.detect(ctx) == {"milestone": 25000}
+
+
+def test_milestone_none_below_first_threshold():
+    ctx = make_ctx(date(2026, 6, 23), total_reviews=9000, sd_conf={"last_shown": {}})
+    assert MILESTONE.detect(ctx) is None
+
+
+def test_milestone_suppressed_after_being_celebrated():
+    ctx = make_ctx(
+        date(2026, 6, 23),
+        total_reviews=30000,
+        sd_conf={"last_shown": {"review_milestone": 25000}},
+    )
+    assert MILESTONE.detect(ctx) is None
+
+
+def test_milestone_reactivates_at_next_tier():
+    ctx = make_ctx(
+        date(2026, 6, 23),
+        total_reviews=60000,
+        sd_conf={"last_shown": {"review_milestone": 25000}},
+    )
+    assert MILESTONE.detect(ctx) == {"milestone": 50000}
+
+
+def test_milestone_already_fired_guard():
+    ctx = make_ctx(date(2026, 6, 23))
+    assert MILESTONE.already_fired("25000", {"milestone": 25000}, ctx) is True
+    assert MILESTONE.already_fired("10000", {"milestone": 25000}, ctx) is False
+    assert MILESTONE.already_fired(None, {"milestone": 10000}, ctx) is False
+
+
+def test_milestone_new_guard_value_is_the_milestone():
+    ctx = make_ctx(date(2026, 6, 23))
+    assert MILESTONE.new_guard_value({"milestone": 50000}, ctx) == 50000
+
+
+# --- StudyAnniversaryOccasion.detect ------------------------------------------
+
+def test_anniversary_today_returns_years():
+    ctx = make_ctx(date(2026, 6, 23), first_review_date=date(2023, 6, 23))
+    assert ANNIVERSARY.detect(ctx) == {"years": 3}
+
+
+def test_anniversary_same_year_is_not_an_anniversary():
+    ctx = make_ctx(date(2023, 6, 23), first_review_date=date(2023, 6, 23))
+    assert ANNIVERSARY.detect(ctx) is None
+
+
+def test_anniversary_without_first_review_returns_none():
+    assert ANNIVERSARY.detect(make_ctx(date(2026, 6, 23))) is None
+
+
+# --- NewYearOccasion.detect ---------------------------------------------------
+
+def test_new_year_fires_on_jan_1():
+    assert NEW_YEAR.detect(make_ctx(date(2026, 1, 1))) == {"year": 2026}
+
+
+def test_new_year_silent_on_other_days():
+    assert NEW_YEAR.detect(make_ctx(date(2026, 1, 2))) is None
+
+
+# --- _build_party_payload: priority resolution + flag plumbing ----------------
+
+def test_payload_is_none_when_nothing_active():
+    assert sd._build_party_payload([], {}) is None
+
+
+def test_payload_birthday_wins_priority_over_new_year():
+    active = [
+        (NEW_YEAR, {"year": 2026}),
+        (BIRTHDAY, {"age": 26}),
+    ]
+    payload = sd._build_party_payload(active, {})
+    assert payload["emoji"] == "🎂"          # birthday's emoji
+    assert payload["accent"] == "#FF5FA2"     # birthday's accent
+    assert set(payload["occasions"]) == {"new_year", "birthday"}
+
+
+def test_payload_single_occasion_uses_its_own_emoji():
+    payload = sd._build_party_payload([(NEW_YEAR, {"year": 2026})], {})
+    assert payload["emoji"] == "🎉"
+
+
+def test_payload_flags_default_on_and_can_be_disabled():
+    on = sd._build_party_payload([(NEW_YEAR, {})], {})
+    assert on["confetti"] is True
+    assert on["heatmap_effect"] is True
+
+    off = sd._build_party_payload(
+        [(NEW_YEAR, {})], {"confetti": False, "heatmap_effect": False}
+    )
+    assert off["confetti"] is False
+    assert off["heatmap_effect"] is False
+
+
+# --- generate_party_accent_css ------------------------------------------------
+
+def test_accent_css_injects_color_under_override_id():
+    css = sd.generate_party_accent_css("#ABCDEF")
+    assert "#ABCDEF" in css
+    assert "onigiri-party-mode-override" in css
+    assert "!important" in css
+
+
+# --- release safety: the debug override must never ship enabled ---------------
+
+def test_debug_force_is_empty_for_release():
+    assert sd.DEBUG_FORCE == set()

--- a/translations.py
+++ b/translations.py
@@ -13,6 +13,20 @@ LANGUAGES = {
 TRANSLATIONS = {
     'en': {
         'general': 'General',
+        # --- Special Days / Party Mode ---
+        'birthday': 'Birthday',
+        'special_days_section': 'Special Days & Party Mode',
+        'special_days_desc': 'Celebrate your birthday, study anniversary, New Year, and lifetime review milestones with confetti and festive touches.',
+        'special_days_enable': 'Enable special days & party mode',
+        'party_confetti': 'All-day confetti',
+        'party_heatmap': 'Festive heatmap effect',
+        'party_accent': 'Festive accent color for the day',
+        'anniversary_toast_title': '🎓 Study Anniversary!',
+        'anniversary_toast_desc': '{years} years since your very first review. Look how far you\'ve come!',
+        'new_year_toast_title': '🎉 Happy New Year!',
+        'new_year_toast_desc': 'Welcome to {year} — a fresh year of learning awaits!',
+        'milestone_toast_title': '🏆 Milestone reached!',
+        'milestone_toast_desc': '{count} lifetime reviews — incredible dedication!',
         'languages': 'Languages',
         'modes': 'Modes',
         'fonts': 'Fonts',

--- a/web/party.css
+++ b/web/party.css
@@ -1,0 +1,80 @@
+/* Onigiri "party mode" — special-day visuals on the deck browser.
+   Injected only on a special day (see inject_menu_files / special_days.py).
+   Loaded AFTER heatmap.css, so the @keyframes glow defined there is reused. */
+
+/* --- Confetti overlay --- */
+.onigiri-party-confetti {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 9000;
+}
+
+.onigiri-party-piece {
+    position: absolute;
+    top: 0;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    will-change: transform, opacity;
+    animation-name: onigiri-party-drift;
+    animation-timing-function: linear;
+    animation-fill-mode: forwards;
+    animation-iteration-count: 1;
+}
+
+@keyframes onigiri-party-drift {
+    0% {
+        transform: translate(0, -24px) rotate(0deg);
+        opacity: 0;
+    }
+    8% {
+        opacity: 1;
+    }
+    100% {
+        transform: translate(var(--drift, 0px), 105vh) rotate(540deg);
+        opacity: 1;
+    }
+}
+
+/* --- Festive glow on today's heatmap cell (reuses @keyframes glow from heatmap.css) --- */
+body.onigiri-party-mode .heatmap-day-cell.today {
+    position: relative;
+    overflow: visible;
+}
+
+body.onigiri-party-mode .heatmap-day-cell.today .day-shape {
+    animation: glow 2.4s ease-in-out infinite;
+}
+
+/* --- Emoji badge on today's cell --- */
+.onigiri-party-emoji {
+    position: absolute;
+    top: -9px;
+    right: -7px;
+    font-size: 13px;
+    line-height: 1;
+    pointer-events: none;
+    z-index: 3;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
+    animation: onigiri-party-bob 2.2s ease-in-out infinite;
+}
+
+@keyframes onigiri-party-bob {
+    0%, 100% {
+        transform: translateY(0) rotate(-6deg);
+    }
+    50% {
+        transform: translateY(-3px) rotate(6deg);
+    }
+}
+
+/* Respect reduced-motion: keep the festive look, drop the movement. */
+@media (prefers-reduced-motion: reduce) {
+    .onigiri-party-piece,
+    .onigiri-party-emoji,
+    body.onigiri-party-mode .heatmap-day-cell.today .day-shape {
+        animation: none !important;
+    }
+}

--- a/web/party.js
+++ b/web/party.js
@@ -1,0 +1,156 @@
+/* Onigiri "party mode" — special-day visuals on the deck browser.
+ *
+ * Reads window.ONIGIRI_PARTY_MODE (injected by inject_menu_files only on a
+ * special day) and layers effects on top of the rendered page:
+ *   - a confetti burst on open, then a gentle, capped continuous drift
+ *   - a festive emoji badge on today's heatmap cell
+ *   - a body class (.onigiri-party-mode) that drives the CSS glow
+ *
+ * It never touches the heatmap's own rendering; it only observes for the
+ * already-existing `.heatmap-day-cell.today` element and decorates it.
+ */
+(function () {
+    if (window.OnigiriParty) {
+        return;
+    }
+
+    var payload = window.ONIGIRI_PARTY_MODE;
+    if (!payload) {
+        return;
+    }
+
+    var PALETTE = [
+        "#ff9800", "#ff5722", "#e91e63", "#9c27b0", "#673ab7", "#3f51b5",
+        "#2196f3", "#03a9f4", "#00bcd4", "#009688", "#4caf50", "#8bc34a",
+        "#cddc39", "#ffeb3b", "#ffc107", "#ff5fa2", "#ffd700"
+    ];
+    function randColor() { return PALETTE[Math.floor(Math.random() * PALETTE.length)]; }
+    function rand(min, max) { return Math.random() * (max - min) + min; }
+
+    var api = { started: false };
+    window.OnigiriParty = api;
+
+    function ready(fn) {
+        if (document.readyState !== "loading" && document.body) {
+            fn();
+        } else {
+            document.addEventListener("DOMContentLoaded", fn, { once: true });
+        }
+    }
+
+    // --- Confetti -------------------------------------------------------------
+    var container = null;
+    var driftTimer = null;
+
+    function ensureContainer() {
+        if (container && document.body.contains(container)) {
+            return container;
+        }
+        container = document.createElement("div");
+        container.className = "onigiri-party-confetti";
+        document.body.appendChild(container);
+        return container;
+    }
+
+    function spawnPiece(fast) {
+        var c = ensureContainer();
+        var piece = document.createElement("div");
+        piece.className = "onigiri-party-piece";
+        var size = rand(6, 12);
+        piece.style.width = size + "px";
+        piece.style.height = size + "px";
+        piece.style.left = rand(0, 100) + "%";
+        piece.style.background = randColor();
+        if (Math.random() < 0.5) {
+            piece.style.borderRadius = "50%";
+        }
+        piece.style.animationDuration = (fast ? rand(1.4, 2.6) : rand(3.5, 6.5)) + "s";
+        piece.style.setProperty("--drift", rand(-60, 60).toFixed(0) + "px");
+        piece.addEventListener("animationend", function () { piece.remove(); });
+        c.appendChild(piece);
+    }
+
+    function burst(n) {
+        for (var i = 0; i < n; i++) {
+            window.setTimeout(function () { spawnPiece(true); }, i * 25);
+        }
+    }
+
+    function startDrift() {
+        if (driftTimer) {
+            return;
+        }
+        driftTimer = window.setInterval(function () {
+            if (document.hidden) {
+                return;
+            }
+            // Keep it gentle: cap the number of live pieces.
+            var live = container ? container.childElementCount : 0;
+            if (live < 24) {
+                spawnPiece(false);
+            }
+        }, 450);
+    }
+
+    function stopConfetti() {
+        if (driftTimer) {
+            window.clearInterval(driftTimer);
+            driftTimer = null;
+        }
+        if (container) {
+            container.remove();
+            container = null;
+        }
+    }
+
+    // --- Heatmap today-cell emoji --------------------------------------------
+    function stampHeatmap() {
+        var cell = document.querySelector(".heatmap-day-cell.today");
+        if (!cell) {
+            return false;
+        }
+        if (cell.querySelector(".onigiri-party-emoji")) {
+            return true;
+        }
+        var span = document.createElement("span");
+        span.className = "onigiri-party-emoji";
+        span.textContent = payload.emoji || "🎉";
+        cell.appendChild(span);
+        return true;
+    }
+
+    function watchHeatmap() {
+        if (stampHeatmap()) {
+            return;
+        }
+        // The heatmap renders asynchronously (OnigiriHeatmap.autoRender), so
+        // wait for today's cell to appear before decorating it.
+        var attempts = 0;
+        var obs = new MutationObserver(function () {
+            if (stampHeatmap() || attempts++ > 60) {
+                obs.disconnect();
+            }
+        });
+        obs.observe(document.body, { childList: true, subtree: true });
+        window.setTimeout(function () { obs.disconnect(); }, 15000);
+    }
+
+    // --- Boot -----------------------------------------------------------------
+    ready(function () {
+        if (api.started) {
+            return;
+        }
+        api.started = true;
+        document.body.classList.add("onigiri-party-mode");
+
+        if (payload.confetti) {
+            burst(40);
+            startDrift();
+        }
+        if (payload.heatmap_effect) {
+            watchHeatmap();
+        }
+
+        window.addEventListener("pagehide", stopConfetti, { once: true });
+    });
+})();


### PR DESCRIPTION
## Summary

Generalizes the existing birthday popup into a reusable **Special Days** engine and adds opt-in **party-mode** visuals.

On profile open, a single cached check decides whether today is special, then drives two independent things:

- **One-shot celebration** (once per occasion, guarded in config): birthday keeps its existing full-screen modal; the new occasions show an `OnigiriNotifications` toast.
- **All-day party visuals** on the deck browser: confetti (a burst on open + a gentle, capped drift), a glow + emoji badge on **today's heatmap cell**, and an optional festive accent override.

### Occasions
- 🎂 **Birthday** — existing modal, now driven by the engine
- 🎓 **Study anniversary** — anniversary of the user's first-ever review
- 🎉 **New Year**
- 🏆 **Lifetime review milestones** — 10k / 25k / 50k / 100k / 250k / 500k / 1M

### Performance
The only new cost is two aggregate `revlog` scalars (`COUNT` and `min(id)`), run **once per profile open** and cached. `get_party_state()` — called during every webview render in `inject_menu_files()` — is pure cached-dict access and runs no SQL. (The heatmap already runs a heavier `revlog` query per render, so this is strictly cheaper than the status quo.)

### Notable details
- **Festive accent is injection-only.** It overrides the accent CSS variable on special-day renders and auto-reverts simply by not being injected afterward — the user's saved theme is never written. It's **off by default** (it recolors the theme); confetti + heatmap effects are on by default.
- Fixes **Feb-29 birthdays** (celebrated on Feb-28 in non-leap years) and the lowercase **"birthday"** settings label (no translation key existed).
- Config migration folds the legacy top-level `lastBirthdayShown` into the new `special_days.last_shown` structure, so existing users don't re-see this year's birthday.
- `prefers-reduced-motion` disables the animations.

### Files
| File | Change |
|---|---|
| `special_days.py` (new) | Engine: occasion registry, per-profile-open cache, `check_and_celebrate()`, `get_party_state()` |
| `web/party.js`, `web/party.css` (new) | Party visuals; today-cell emoji via `MutationObserver`; reuses the existing `@keyframes glow` |
| `__init__.py` | Import, warm cache + swap the birthday timer to the engine, gated injection, invalidate cache on profile switch |
| `config.py` | `special_days` schema + migration |
| `settings.py` | Master + confetti/heatmap/festive-accent toggles in the Profile tab |
| `translations.py` | `en` strings |

### Testing
- All Python compiles; `party.js` passes `node --check`.
- The pure date / milestone / priority logic — including the Feb-29 edge cases and the milestone guard — is covered by standalone checks.
- Manual: **Settings → Profile → set birthday to today → Save → reopen profile.** A `DEBUG_FORCE` set in `special_days.py` (empty for release) can force the other occasions for testing.

### v1 limitations / possible follow-ups
- Party mode is evaluated per render/open; if Anki is left open across midnight the visuals refresh on the next navigation rather than live (a midnight `QTimer` could be added).
- Milestones are detected at profile open, not the instant a review crosses the threshold (a `reviewer_did_answer_card` hook could make it live).
- New strings are English-only for now and fall back gracefully for other locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
