### PR TITLE
fix: Heatmap navigation arrow color syncing

### DIFF
--- a/web/heatmap.css
+++ b/web/heatmap.css
@@ -216,7 +216,7 @@
 .nav-btn svg {
     width: 14px;
     height: 14px;
-    fill: var(--fg);
+    fill: currentColor;
     pointer-events: none;
 }
 


### PR DESCRIPTION
Fixes an issue where the heatmap navigation arrows blend into the background in dark mode due to improper handling of `--fg` inside SVG fills in the webview. Uses standard `currentColor` to dynamically inherit the proper text color based on the parent element styling.

---
*PR created automatically by Jules for task [2843618946191430270](https://jules.google.com/task/2843618946191430270) started by @h0tp-ftw*