### PR TITLE
Fix startup deadlock on macOS caused by sync popup and welcome overlay

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -604,7 +604,7 @@ def on_profile_did_open():
 
     # Check for sync conflicts on startup
     if onigiri_sync.is_enabled():
-        QTimer.singleShot(1000, on_sync_did_finish)
+        QTimer.singleShot(3000, on_sync_did_finish)
 
     # Show birthday popup if it's the user's birthday (requires mw.col)
     # Delay to ensure the main window is fully rendered before opening a dialog.


### PR DESCRIPTION
Fixes an issue where Anki freezes on startup if both the Welcome to Onigiri popup and the Sync Conflict popup appear simultaneously. Increased the startup delay for `on_sync_did_finish` so the sync check waits for the webview to render properly.

---
*PR created automatically by Jules for task [5915379290560096446](https://jules.google.com/task/5915379290560096446) started by @h0tp-ftw*