### PR TITLE
fix: prevent Anki default hover styles from hiding birthday button text

### DIFF
--- a/web/birthday.html
+++ b/web/birthday.html
@@ -135,9 +135,9 @@
         }
 
         .btn-thank-you {
-            background: var(--accent-color);
-            color: white;
-            border: none;
+            background: var(--accent-color) !important;
+            color: white !important;
+            border: none !important;
             padding: 12px 30px;
             font-size: 16px;
             font-weight: 600;
@@ -149,6 +149,8 @@
         }
 
         .btn-thank-you:hover {
+            background: var(--accent-color) !important;
+            color: white !important;
             transform: translateY(-2px);
             box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
         }


### PR DESCRIPTION
This PR adds !important to the background and color of the "Thank you!" button in the birthday webview to prevent Anki's default button styles from making the text invisible on hover.

---
*PR created automatically by Jules for task [853814320861853350](https://jules.google.com/task/853814320861853350) started by @h0tp-ftw*