### PR TITLE
Fix button corner radius disappearing when pressed

### DIFF
--- a/settings/_font_picker.py
+++ b/settings/_font_picker.py
@@ -182,17 +182,21 @@ class FontPickerDialog(QDialog):
             f"QPushButton {{ background: rgba(128,128,128,0.10); color: {self._fg};"
             f" border: 1px solid {self._border}; border-radius: 18px; padding: 0 18px; font-weight: 700; }}"
             f" QPushButton:hover {{ border-color: {self._accent}; }}"
+            f" QPushButton:pressed {{ background: rgba(128,128,128,0.20); border-radius: 18px; }}"
         )
         hover = QColor(self._accent).lighter(110).name()
+        pressed = QColor(self._accent).darker(110).name()
         self.save_btn.setStyleSheet(
             f"QPushButton {{ background: {self._accent}; color: #ffffff; border: none;"
             f" border-radius: 18px; padding: 0 20px; font-weight: 700; }}"
             f" QPushButton:hover {{ background: {hover}; }}"
+            f" QPushButton:pressed {{ background: {pressed}; border-radius: 18px; }}"
         )
         for btn in (self.cancel_btn, self.reset_btn):
             btn.setStyleSheet(
                 f"QPushButton {{ background: {self._surface}; color: {self._fg};"
                 f" border: 1px solid {self._border}; border-radius: 18px; padding: 0 18px; }}"
+                f" QPushButton:pressed {{ background: rgba(128,128,128,0.10); border-radius: 18px; }}"
             )
 
     def _on_preview_mode_toggled(self, mode):

--- a/settings/_title_editor.py
+++ b/settings/_title_editor.py
@@ -235,17 +235,21 @@ class StatsTitleDialog(QDialog):
             f"QPushButton {{ background: rgba(128,128,128,0.10); color: {self._fg};"
             f" border: 1px solid {self._border}; border-radius: 18px; padding: 0 18px; font-weight: 700; }}"
             f" QPushButton:hover {{ border-color: {self._accent}; }}"
+            f" QPushButton:pressed {{ background: rgba(128,128,128,0.20); border-radius: 18px; }}"
         )
         hover = QColor(self._accent).lighter(110).name()
+        pressed = QColor(self._accent).darker(110).name()
         self.save_btn.setStyleSheet(
             f"QPushButton {{ background: {self._accent}; color: #ffffff; border: none;"
             f" border-radius: 18px; padding: 0 20px; font-weight: 700; }}"
             f" QPushButton:hover {{ background: {hover}; }}"
+            f" QPushButton:pressed {{ background: {pressed}; border-radius: 18px; }}"
         )
         for btn in (self.cancel_btn, self.reset_btn):
             btn.setStyleSheet(
                 f"QPushButton {{ background: {self._surface}; color: {self._fg};"
                 f" border: 1px solid {self._border}; border-radius: 18px; padding: 0 18px; }}"
+                f" QPushButton:pressed {{ background: rgba(128,128,128,0.10); border-radius: 18px; }}"
             )
         self._style_counter()
 

--- a/settings/_widget_grid_v2.py
+++ b/settings/_widget_grid_v2.py
@@ -829,6 +829,7 @@ class WidgetGridEditorV2(QWidget):
             f"QPushButton{{background:{accent};color:{fg};border:none;"
             f"border-radius:{radius}px;padding:8px 16px;font-weight:700;font-size:13px;}}"
             f"QPushButton:hover{{background:{_shade(accent, 0.9)};}}"
+            f"QPushButton:pressed{{background:{_shade(accent, 0.8)};border-radius:{radius}px;}}"
         )
 
     def _cell_height_for(self, widget_height):


### PR DESCRIPTION
Fixes a bug reported by users where clicking "Add Widget" and other similar buttons in dialogs resulted in the button temporarily losing its rounded corners.

---
*PR created automatically by Jules for task [3904346801139746838](https://jules.google.com/task/3904346801139746838) started by @h0tp-ftw*