### PR TITLE
fix(ui): Adjust heatmap filter pill and button margins/radius

### DIFF
--- a/web/heatmap 3.css
+++ b/web/heatmap 3.css
@@ -134,7 +134,7 @@
     bottom: 2px;
     left: 0;
     width: 0;
-    border-radius: 6px;
+    border-radius: 4px;
     background-color: var(--accent-color);
     pointer-events: none;
     transition: transform 0.18s cubic-bezier(0.16, 1, 0.3, 1), width 0.18s cubic-bezier(0.16, 1, 0.3, 1);
@@ -150,13 +150,14 @@
     z-index: 1;
     border: none;
     background-color: transparent;
-    border-radius: 6px;
+    border-radius: 4px;
     cursor: pointer;
     font: var(--font-main);
     font-size: 12px;
     font-weight: 500;
     color: var(--fg-subtle);
     box-shadow: none !important;
+    margin: 0 !important;
 
     /* Fixed Height Logic */
     height: 24px;

--- a/web/heatmap.css
+++ b/web/heatmap.css
@@ -134,7 +134,7 @@
     bottom: 2px;
     left: 0;
     width: 0;
-    border-radius: 6px;
+    border-radius: 4px;
     background-color: var(--accent-color);
     pointer-events: none;
     transition: transform 0.18s cubic-bezier(0.16, 1, 0.3, 1), width 0.18s cubic-bezier(0.16, 1, 0.3, 1);
@@ -150,13 +150,14 @@
     z-index: 1;
     border: none;
     background-color: transparent;
-    border-radius: 6px;
+    border-radius: 4px;
     cursor: pointer;
     font: var(--font-main);
     font-size: 12px;
     font-weight: 500;
     color: var(--fg-subtle);
     box-shadow: none !important;
+    margin: 0 !important;
 
     /* Fixed Height Logic */
     height: 24px;


### PR DESCRIPTION
This Pull Request fixes an unintentional gap in the heatmap widget's pill switcher caused by Anki's default button margins and adjusts the inner pill's border radius to aesthetically match the outer container.

Changes made:
- Added `margin: 0 !important;` to `.filter-btn` to override Anki's default styling, fixing the uneven spacing.
- Reduced the `border-radius` of `.heatmap-filter-pill` and `.filter-btn` from `6px` to `4px`.
- Applied changes to both `web/heatmap.css` and `web/heatmap 3.css`.

---
*PR created automatically by Jules for task [4416147097554586986](https://jules.google.com/task/4416147097554586986) started by @h0tp-ftw*