### PR TITLE
Fix reviewer layout observer lag and accumulation leak

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -260,6 +260,8 @@ def inject_menu_files(web_content, context):
             window.onigiriNotificationPositionCssText = {json.dumps(generate_notification_position_css_text(conf))};
 
             document.addEventListener('DOMContentLoaded', function() {{
+                if (window.onigiriReviewerInitialized) return;
+                window.onigiriReviewerInitialized = true;
                 const hostId = 'onigiri-reviewer-ui-host';
                 const topBarHtml = {json.dumps(top_bar_html)};
                 const topBarCss = {json.dumps(reviewer_shadow_css)};
@@ -393,8 +395,12 @@ def inject_menu_files(web_content, context):
                     themeObserver.observe(document.body, {{ attributes: true, attributeFilter: ['class'] }});
                 }}
 
+                let qaObserverTimeout = null;
                 const qaObserver = new MutationObserver(() => {{
-                    applyQaOffset(window.onigiriReviewerHeaderOffsetPx || 0);
+                    if (qaObserverTimeout) clearTimeout(qaObserverTimeout);
+                    qaObserverTimeout = setTimeout(() => {{
+                        applyQaOffset(window.onigiriReviewerHeaderOffsetPx || 0);
+                    }}, 50);
                 }});
                 if (document.body) {{
                     qaObserver.observe(document.body, {{ childList: true, subtree: true }});


### PR DESCRIPTION
This commit addresses the lag users were experiencing when reviewing cards in Anki, particularly complex cards from decks like AnKing. 

The issue had two parts:
1. The `qaObserver` in `__init__.py` was firing synchronously on every tiny DOM mutation, causing excessive layout recalculations. This was fixed by wrapping the offset logic in a 50ms debounce.
2. The `DOMContentLoaded` listener that sets up these observers could run multiple times during a long study session, stacking up multiple observers and leading to severe lag over time. This was fixed by guarding the initialization logic with a `window.onigiriReviewerInitialized` flag.

---
*PR created automatically by Jules for task [6016778841315284972](https://jules.google.com/task/6016778841315284972) started by @h0tp-ftw*