### PR TITLE
Fix reviewer bottom bar outlines and sidebar profile overlap

### DIFF
--- a/onigiri_renderer.py
+++ b/onigiri_renderer.py
@@ -3353,6 +3353,14 @@ def render_onigiri_deck_browser(self: DeckBrowser, reuse: bool = False) -> None:
         rl_theme_color = chip_vals.get("progress", "")
 
     if rl_theme_color:
+
+        # Determine the stroke for the level chip
+        chip_stroke_size = conf.get("onigiri_canvas_inset_border_width", 1)
+        overview_style = conf.get("overview_style", {}) if isinstance(conf.get("overview_style", {}), dict) else {}
+        overview_colors = overview_style.get("colors", {}) if isinstance(overview_style.get("colors", {}), dict) else {}
+        chip_border_color_light = overview_colors.get("light", {}).get("box_border") or conf.get("colors", {}).get("light", {}).get("--border", "#e0e0e0")
+        chip_border_color_dark = overview_colors.get("dark", {}).get("box_border") or conf.get("colors", {}).get("dark", {}).get("--border", "#424242")
+
         theme_css = f"""
         <style id="profile-bar-theme-colors">
             .profile-bar .restaurant-level-chip .rl-chip-progress {{
@@ -3369,6 +3377,15 @@ def render_onigiri_deck_browser(self: DeckBrowser, reuse: bool = False) -> None:
             
             .level-progress-bar {{
                 background: {rl_theme_color} !important;
+            }}
+
+            .restaurant-level-chip {{
+                border: {chip_stroke_size}px solid {chip_border_color_light} !important;
+            }}
+
+            .night-mode .restaurant-level-chip,
+            .nightMode .restaurant-level-chip {{
+                border: {chip_stroke_size}px solid {chip_border_color_dark} !important;
             }}
         </style>
         """

--- a/patcher.py
+++ b/patcher.py
@@ -6336,6 +6336,15 @@ def generate_reviewer_buttons_css(conf):
     radius = conf.get("onigiri_reviewer_btn_radius", 12)
     padding = conf.get("onigiri_reviewer_btn_padding", 5)
     btn_height = conf.get("onigiri_reviewer_btn_height", 40)
+    border_size = conf.get("onigiri_canvas_inset_border_width", 1)
+
+    # We use the generic border color config if there's no specific reviewer config
+    # Fallback appropriately for standard widget border colors
+    overview_style = conf.get("overview_style", {}) if isinstance(conf.get("overview_style", {}), dict) else {}
+    overview_colors = overview_style.get("colors", {}) if isinstance(overview_style.get("colors", {}), dict) else {}
+
+    border_color_light = overview_colors.get("light", {}).get("box_border") or conf.get("colors", {}).get("light", {}).get("--border", "#e0e0e0")
+    border_color_dark = overview_colors.get("dark", {}).get("box_border") or conf.get("colors", {}).get("dark", {}).get("--border", "#424242")
     bar_height = _reviewer_bottom_bar_height_px(conf)
 
     stattxt_mode = conf.get("onigiri_reviewer_stattxt_mode", "hover")
@@ -6447,6 +6456,7 @@ def generate_reviewer_buttons_css(conf):
             --onigiri-reviewer-review-count-bg: {_overview_count_color("light", "review_bubble", "--review-count-bubble-bg", "#ff5757")};
             --onigiri-reviewer-review-count-fg: {_overview_count_color("light", "review_text", "--review-count-bubble-fg", "#ffffff")};
             --onigiri-answer-hover-number-color: {answer_hover_number_color_light};
+            --onigiri-reviewer-btn-border: {border_size}px solid {border_color_light};
         }}
 
         .nightMode,
@@ -6458,6 +6468,7 @@ def generate_reviewer_buttons_css(conf):
             --onigiri-reviewer-review-count-bg: {_overview_count_color("dark", "review_bubble", "--review-count-bubble-bg", "#ff453a")};
             --onigiri-reviewer-review-count-fg: {_overview_count_color("dark", "review_text", "--review-count-bubble-fg", "#fff5f5")};
             --onigiri-answer-hover-number-color: {answer_hover_number_color_dark};
+            --onigiri-reviewer-btn-border: {border_size}px solid {border_color_dark};
         }}
 
         body .stattxt:not(.onigiri-count-pill),
@@ -6836,7 +6847,7 @@ def generate_reviewer_buttons_css(conf):
         }}
 
         button {{
-            border: 2px solid transparent !important;
+            border: var(--onigiri-reviewer-btn-border, 2px solid transparent) !important;
             border-radius: {radius}px !important;
             box-shadow: none !important;
             /* Only color/background transition (quick hover feedback) - no

--- a/web/injector.js
+++ b/web/injector.js
@@ -57,7 +57,7 @@
         const expandedContent = sidebar ? sidebar.querySelector('.sidebar-expanded-content') : null;
         if (!toolbar || !expandedContent) return;
 
-        const profileBar = expandedContent.querySelector('.profile-bar');
+        const profileBar = expandedContent.querySelector('.profile-bar, .onigiri-profile');
         toolbar.classList.add('sidebar-actions-inline');
         if (profileBar) {
             profileBar.insertAdjacentElement('afterend', toolbar);


### PR DESCRIPTION
Resolves multiple UI suggestions and bugs:
- Applies the widget border settings (`onigiri_canvas_inset_border_width` and colors) to the reviewer bottom bar buttons for a cohesive design.
- Applies the same widget border settings to the restaurant level chip (`.restaurant-level-chip`).
- Fixes a bug in the sidebar UI where the collapsed action bar would render above the profile if the profile was set to "ring mode" by ensuring `injector.js` can find `.onigiri-profile`.

---
*PR created automatically by Jules for task [9749810973609481361](https://jules.google.com/task/9749810973609481361) started by @h0tp-ftw*