### PR TITLE
fix: prevent sidebar review counts from clipping when narrowed

### DIFF
--- a/web/menu.css
+++ b/web/menu.css
@@ -1309,7 +1309,7 @@ tr.deck.is-subdeck .deck-info,
 tr.deck.is-filtered .deck-info {
     display: flex;
     align-items: center;
-    flex: 1;
+    flex: 1 1 0;
     min-width: 0;
     width: 0;
     max-width: 100%;
@@ -1324,7 +1324,7 @@ tr.deck.is-filtered .deck-counts {
     display: flex;
     align-items: center;
     gap: 4px;
-    flex: 0 1 auto;
+    flex: 0 0 auto;
     /* Overrides margin-left/padding-left from the base .deck-counts rule, then
        pulls the bubbles back over the name box. The bubbles keep their position
        (.deck-info just grows by the same amount); only the overlap changes.
@@ -3098,10 +3098,10 @@ td.count {
     align-items: center;
     gap: 4px;
     padding-left: 4px;
-    flex: 0 1 auto;
+    flex: 0 0 auto;
     justify-content: flex-end;
     min-width: 0;
-    max-width: 48%;
+    max-width: none;
     overflow: hidden;
 }
 
@@ -3120,11 +3120,10 @@ tr.deck .learn-count-bubble {
     min-width: 1.5em;
     text-align: center;
     line-height: 1;
-    max-width: 5ch;
+    max-width: none;
     flex: 0 0 auto;
-    overflow: hidden;
+    overflow: visible;
     white-space: nowrap;
-    text-overflow: ellipsis;
 }
 
 /* Sidebar count bubbles follow whatever the Overviewer's card count colors


### PR DESCRIPTION
This PR fixes an issue where review count numbers in the sidebar get cut off when the sidebar is dragged to be very narrow. By adjusting flexbox priorities in `web/menu.css`, the deck name will now correctly shrink (and truncate) to make space, while the count bubbles maintain their natural width and remain fully visible.

---
*PR created automatically by Jules for task [277183712936424986](https://jules.google.com/task/277183712936424986) started by @h0tp-ftw*