### PR TITLE
fix: compatibility with Speed Focus addon timer text extraction

### DIFF
--- a/patcher.py
+++ b/patcher.py
@@ -7034,7 +7034,7 @@ def generate_reviewer_buttons_css(conf):
             let onigiriLastKnownStats = null;
 
             function cleanText(value) {
-                return (value || '').replace(/\\s+/g, ' ').trim();
+                return (value || '').replace(/[\u200E\u200F\u202A-\u202E\u2066-\u2069]/g, '').replace(/\\s+/g, ' ').trim();
             }
 
             function buttonTextWithoutOnigiri(btn) {
@@ -7117,7 +7117,7 @@ def generate_reviewer_buttons_css(conf):
             // look for a leaf element whose own text matches the mm:ss shape, which
             // intervals/counts never do. Scoped to #outer so we never touch card text.
             function isOnigiriTimerText(text) {
-                return /^\d{1,2}:\d{2}$/.test(text);
+                return /^\D*\d{1,2}:\d{2}\D*$/.test(text);
             }
 
             function findOnigiriNativeTimerNode() {


### PR DESCRIPTION
Fixes a bug where remaining card counts display as "0" when the "Speed Focus" add-on is active. The fix strips invisible formatting characters injected by the add-on and makes the timer detection regex more robust.

---
*PR created automatically by Jules for task [13400307643405352848](https://jules.google.com/task/13400307643405352848) started by @h0tp-ftw*