### PR TITLE
fix(focus_dango): prevent blocking key presses when text input is focused

### DIFF
--- a/gamification/focus_dango.py
+++ b/gamification/focus_dango.py
@@ -215,6 +215,18 @@ class KeyEventFilter(QtCore.QObject):
             ):
                 return False
 
+            # Don't intercept shortcuts if the active window is not the main Anki window
+            # (e.g., if the user is using the "Edit Current", "Add Card", or "Browse" dialogs)
+            active_window = mw.app.activeWindow()
+            if active_window is not mw:
+                return False
+
+            # Don't intercept shortcuts if focus is on any input field
+            focus_widget = mw.app.focusWidget()
+            from PyQt6.QtWidgets import QLineEdit, QTextEdit, QPlainTextEdit, QAbstractSpinBox
+            if isinstance(focus_widget, (QLineEdit, QTextEdit, QPlainTextEdit, QAbstractSpinBox)):
+                return False
+
             navigation_keys = {
                 Qt.Key.Key_D: 'onDeckBrowser',  # 'd' key
                 Qt.Key.Key_B: 'onBrowse',       # 'b' key


### PR DESCRIPTION
Fixes an issue where Focus Dango's Self-Sabotage feature prevented users from typing specific letters (like 'a', 'e', 'i', 'b') while editing cards during a review session. The global key event filter now properly ignores key presses when a text input widget is focused or a secondary dialog window is active.

---
*PR created automatically by Jules for task [14921055865236007732](https://jules.google.com/task/14921055865236007732) started by @h0tp-ftw*