### PR TITLE
fix: prevent native Anki filtered deck descriptions from triggering 'Click to reveal' button

### DIFF
--- a/patcher.py
+++ b/patcher.py
@@ -2360,7 +2360,7 @@ def patch_overview():
         const allExternalElements = [];
         if (container) {
             Array.from(container.children).forEach(function(child) {
-                // Skip Onigiri elements and the reveal button
+                // Skip Onigiri elements, reveal button, and Anki's native share/desc divs
                 if (child !== onigiriHeader &&
                     !child.classList.contains('overview-profile-bar') &&
                     child !== onigiriTitle && 
@@ -2370,7 +2370,9 @@ def patch_overview():
                     child.id !== 'onigiri-reveal-btn' &&
                     !child.classList.contains('overview-header') &&
                     !child.classList.contains('overview-title') &&
-                    !child.classList.contains('overview-container')) {
+                    !child.classList.contains('overview-container') &&
+                    !child.classList.contains('overview-share') &&
+                    !child.classList.contains('overview-desc')) {
                     
                     // Check if element has any meaningful content instantly
                     const hasVisibleContent = function(el) {
@@ -2466,8 +2468,8 @@ def patch_overview():
 	<h3 class="overview-title">%(deck)s</h3>
 	{profile_bar_html}
 	%(table)s
-	<div>%(shareLink)s</div>
-	<div>%(desc)s</div>
+	<div class="overview-share">%(shareLink)s</div>
+	<div class="overview-desc">%(desc)s</div>
 </div>
 <script>{js_code}</script>
 {late_background_css}


### PR DESCRIPTION
The add-on uses a masking script to sweep "unrecognized" overview content (usually injected by third-party add-ons) behind a 'Click to reveal' toggle button. 
However, for filtered decks, Anki sometimes renders empty `%(desc)s` and `%(shareLink)s` native elements. Since these had no specific identifiable classes, the Onigiri masking script treated them as external add-ons, causing an erroneous and useless 'Click to reveal' button to appear.

This commit resolves the issue by adding class tags to those native description and share divs, and explicitly bypassing them in the script's `allExternalElements` discovery loop.

---
*PR created automatically by Jules for task [11217241115640556672](https://jules.google.com/task/11217241115640556672) started by @h0tp-ftw*