### PR TITLE
Fix reviewer lag and memory leak by debouncing mutation observers

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -345,6 +345,9 @@ def inject_menu_files(web_content, context):
             window.onigiriNotificationMode = {json.dumps(conf.get("onigiri_reviewer_notification_mode", "classic"))};
 
             document.addEventListener('DOMContentLoaded', function() {{
+                if (window.onigiriReviewerInitialized) return;
+                window.onigiriReviewerInitialized = true;
+
                 const hostId = 'onigiri-reviewer-ui-host';
                 const topBarHtml = {json.dumps(top_bar_html)};
                 const topBarCss = {json.dumps(reviewer_shadow_css)};
@@ -469,17 +472,25 @@ def inject_menu_files(web_content, context):
                     resizeObserver.observe(headerEl);
                 }}
 
+                let themeTimeout;
                 const themeObserver = new MutationObserver(() => {{
-                    updateHostTheme();
-                    updateHeaderOffset();
+                    clearTimeout(themeTimeout);
+                    themeTimeout = setTimeout(() => {{
+                        updateHostTheme();
+                        updateHeaderOffset();
+                    }}, 50);
                 }});
                 themeObserver.observe(document.documentElement, {{ attributes: true, attributeFilter: ['class'] }});
                 if (document.body) {{
                     themeObserver.observe(document.body, {{ attributes: true, attributeFilter: ['class'] }});
                 }}
 
+                let qaTimeout;
                 const qaObserver = new MutationObserver(() => {{
-                    applyQaOffset(window.onigiriReviewerHeaderOffsetPx || 0);
+                    clearTimeout(qaTimeout);
+                    qaTimeout = setTimeout(() => {{
+                        applyQaOffset(window.onigiriReviewerHeaderOffsetPx || 0);
+                    }}, 50);
                 }});
                 if (document.body) {{
                     qaObserver.observe(document.body, {{ childList: true, subtree: true }});


### PR DESCRIPTION
Fixes performance issues (lag) when reviewing cards. The add-on uses `MutationObserver` to watch for theme and layout changes. Previously, these observers fired too frequently without a delay (debouncing), causing Anki to become sluggish, especially on complex cards. Additionally, the observer setup script could run multiple times, creating duplicate listeners.

This fix:
1. Adds a 50ms debounce timeout to the observer callbacks so they don't fire continuously.
2. Uses a global window flag (`window.onigiriReviewerInitialized`) to ensure the listeners are only attached once.

---
*PR created automatically by Jules for task [6241064853283334985](https://jules.google.com/task/6241064853283334985) started by @h0tp-ftw*