### PR TITLE
Fix Prep Station and Stats Widget opacity syncing

### DIFF
--- a/config.py
+++ b/config.py
@@ -125,6 +125,13 @@ DEFAULTS = {
     "prep_station": {
         "plans": [],
     },
+    "prep_station_style": {
+        "sync_box_effect": True,
+        "blur": 0,
+        "opacity": 100,
+        "radius": 20,
+        "stroke": 1,
+    },
     "hashi_notes": {
         "retention_default": 30,
         "custom_css": "",

--- a/onigiri_renderer.py
+++ b/onigiri_renderer.py
@@ -2037,11 +2037,11 @@ def render_onigiri_deck_browser(self: DeckBrowser, reuse: bool = False) -> None:
             cursor: pointer;
             overflow: hidden;
             font-family: inherit;
-            /* background + border-radius/width fall back here, then get
-               overridden !important by the Widget Color & Effect settings */
-            background-color: var(--canvas-inset, #f2f2f2);
-            border: 1px solid var(--border, rgba(128, 128, 128, 0.24));
-            border-radius: 15px;
+            background-color: var(--prep-box-bg, var(--canvas-inset, #f2f2f2));
+            border: var(--prep-box-stroke, 1px) solid var(--prep-box-border, var(--border, rgba(128, 128, 128, 0.24)));
+            border-radius: var(--prep-box-radius, 15px);
+            backdrop-filter: blur(var(--prep-box-blur, 0px));
+            -webkit-backdrop-filter: blur(var(--prep-box-blur, 0px));
         }}
         .prep-widget-empty {{
             flex: 1;

--- a/patcher.py
+++ b/patcher.py
@@ -6360,10 +6360,10 @@ def generate_dynamic_css(conf):
 
 	def _deck_stats_box_bg(mode: str, fallback_key: str, fallback: str) -> str:
 		if deck_stats_sync:
-			# Already carries the box opacity/blur alpha from _apply_canvas_inset_effect.
 			source = light_colors if mode == "light" else dark_colors
 			return source.get(fallback_key, fallback)
-		color = _deck_stats_color(mode, "box_bg", fallback)
+		# Start from raw color, not mutated
+		color = _deck_stats_color(mode, "box_bg", raw_box_light if mode == "light" else raw_box_dark)
 		alpha = deck_stats_opacity / 100.0
 		if deck_stats_blur > 0:
 			alpha = min(alpha, 0.62)
@@ -6458,7 +6458,10 @@ def generate_dynamic_css(conf):
 			box_bg = theme.get("--canvas-inset", sw_fallback_colors[mode]["box_bg"])
 			box_border = theme.get("--border", sw_fallback_colors[mode]["box_border"])
 		else:
+			# Fallback for custom styling, avoid double-applying global alpha by taking raw color
 			box_bg = _sw_color(mode, "box_bg")
+			if box_bg == sw_fallback_colors[mode]["box_bg"]:
+				box_bg = raw_box_light if mode == "light" else raw_box_dark
 			alpha = sw_opacity / 100.0
 			if sw_blur > 0:
 				alpha = min(alpha, 0.62)
@@ -6549,6 +6552,46 @@ def generate_dynamic_css(conf):
 
 	overview_light_rules.extend(_hw_rules("light"))
 	overview_dark_rules.extend(_hw_rules("dark"))
+
+	# --- Prep Station dashboard widget ---
+	prep_station_style = conf.get("prep_station_style", {}) if isinstance(conf.get("prep_station_style", {}), dict) else {}
+	ps_sync = bool(prep_station_style.get("sync_box_effect", True))
+	ps_blur = box_effect_blur if ps_sync else max(0, min(100, int(prep_station_style.get("blur", 0) or 0)))
+	ps_opacity = box_effect_opacity if ps_sync else max(0, min(100, int(prep_station_style.get("opacity", 100) or 100)))
+	ps_radius = box_effect_radius if ps_sync else max(0, min(60, _int_style_value(prep_station_style.get("radius", 20), 20)))
+	ps_stroke = box_effect_stroke if ps_sync else max(0, min(10, _int_style_value(prep_station_style.get("stroke", 1), 1)))
+
+	def _ps_rules(mode: str) -> list:
+		if ps_sync:
+			theme = light_colors if mode == "light" else dark_colors
+			# `theme` already has the alpha/blur applied from _apply_canvas_inset_effect globally
+			# But we need to use raw_box_light / raw_box_dark so we don't double-apply the alpha in _apply_canvas_inset_effect
+			# wait, _apply_canvas_inset_effect mutates light_colors/dark_colors directly
+			box_bg = theme.get("--canvas-inset", "#ffffff" if mode == "light" else "#2c2c2c")
+			box_border = theme.get("--border", "#e0e0e0" if mode == "light" else "#424242")
+		else:
+			# Fallback for custom styling
+			theme = light_colors if mode == "light" else dark_colors
+			base_bg = raw_box_light if mode == "light" else raw_box_dark
+			base_border = theme.get("--border", "#e0e0e0" if mode == "light" else "#424242")
+
+			alpha = ps_opacity / 100.0
+			if ps_blur > 0:
+				alpha = min(alpha, 0.62)
+
+			box_bg = _onigiri_css_color_with_alpha(base_bg, alpha)
+			box_border = base_border
+
+		return [
+			f"    --prep-box-bg: {box_bg} !important;",
+			f"    --prep-box-border: {box_border} !important;",
+			f"    --prep-box-radius: {ps_radius}px !important;",
+			f"    --prep-box-stroke: {ps_stroke}px !important;",
+			f"    --prep-box-blur: {(ps_blur / 100.0) * 20:.2f}px !important;",
+		]
+
+	overview_light_rules.extend(_ps_rules("light"))
+	overview_dark_rules.extend(_ps_rules("dark"))
 
 	# --- START: Calculate Heatmap Colors (to avoid CSS color-mix) ---
 	heatmap_style = conf.get("heatmap_style", {}) if isinstance(conf.get("heatmap_style", {}), dict) else {}
@@ -6675,7 +6718,7 @@ def generate_dynamic_css(conf):
 	if box_effect_blur > 0:
 		blur_px = (box_effect_blur / 100.0) * 20
 		# --- FIX: Added heatmap container IDs to the selectors ---
-		glass_selectors = ".stat-card, #onigiri-heatmap-container, #onigiri-profile-heatmap-container, .prep-station-widget"
+		glass_selectors = "#onigiri-heatmap-container, #onigiri-profile-heatmap-container"
 		glass_style_block = f"""
         <style id="onigiri-glass-effect">
         {glass_selectors} {{
@@ -6685,7 +6728,7 @@ def generate_dynamic_css(conf):
         </style>
         """
 
-	box_selectors = ".stat-card, #onigiri-heatmap-container, #onigiri-profile-heatmap-container, .onigiri-favorites-widget, .onigimon-widget, .hex-land-widget, .prep-station-widget"
+	box_selectors = "#onigiri-heatmap-container, #onigiri-profile-heatmap-container, .onigiri-favorites-widget, .onigimon-widget, .hex-land-widget"
 	box_shape_style_block = f"""
         <style id="onigiri-box-shape-effect">
         {box_selectors} {{

--- a/settings_web/schema.py
+++ b/settings_web/schema.py
@@ -1094,13 +1094,40 @@ def _prep_station_page():
                 "prep_widget",
                 title=tr("prep_widget_section_title", "Study Plans Widget"),
                 icon="square.svg",
-                fields=[{
-                    "id": "prep_widget_font_scale", "type": "slider",
-                    "label": tr("prep_widget_font_label", "Font Size"),
-                    "desc": tr("prep_widget_font_desc", "Font size of the Study Plans preview shown on the deck browser widget."),
-                    "bind": col("onigiri_prep_station_widget_font_scale", 100), "default": 100,
-                    "min": 60, "max": 160, "step": 1, "suffix": "%",
-                }],
+                sync_toggle_id="prep_widget_sync_box_effect",
+                sync_hidden_fields=[
+                    "prep_widget_blur", "prep_widget_opacity", "prep_widget_radius", "prep_widget_stroke",
+                ],
+                fields=[
+                    {
+                        "id": "prep_widget_sync_box_effect", "type": "toggle",
+                        "label": tr("sync_with_box_effect", "Sync with Widget Color and Effect"),
+                        "bind": {"kind": "config", "path": ["prep_station_style", "sync_box_effect"]}, "default": True,
+                    },
+                    {
+                        "id": "prep_widget_blur", "type": "slider", "label": tr("blur", "Blur"),
+                        "bind": {"kind": "config", "path": ["prep_station_style", "blur"]}, "default": 0, "min": 0, "max": 100, "suffix": "%",
+                    },
+                    {
+                        "id": "prep_widget_opacity", "type": "slider", "label": tr("opacity", "Opacity"),
+                        "bind": {"kind": "config", "path": ["prep_station_style", "opacity"]}, "default": 100, "min": 0, "max": 100, "suffix": "%",
+                    },
+                    {
+                        "id": "prep_widget_radius", "type": "slider", "label": tr("border_radius", "Border Radius"),
+                        "bind": {"kind": "config", "path": ["prep_station_style", "radius"]}, "default": 20, "min": 0, "max": 60, "suffix": "px",
+                    },
+                    {
+                        "id": "prep_widget_stroke", "type": "slider", "label": tr("border_width", "Border Width"),
+                        "bind": {"kind": "config", "path": ["prep_station_style", "stroke"]}, "default": 1, "min": 0, "max": 10, "suffix": "px",
+                    },
+                    {
+                        "id": "prep_widget_font_scale", "type": "slider",
+                        "label": tr("prep_widget_font_label", "Font Size"),
+                        "desc": tr("prep_widget_font_desc", "Font size of the Study Plans preview shown on the deck browser widget."),
+                        "bind": col("onigiri_prep_station_widget_font_scale", 100), "default": 100,
+                        "min": 60, "max": 160, "step": 1, "suffix": "%",
+                    }
+                ],
             ),
         ],
     }

--- a/web/menu.css
+++ b/web/menu.css
@@ -2330,9 +2330,11 @@ tr.deck.drag-over-nest {
     cursor: pointer;
     overflow: hidden;
     font-family: inherit;
-    background-color: var(--canvas-inset, #f2f2f2);
-    border: 1px solid var(--border, rgba(128, 128, 128, 0.24));
-    border-radius: 15px;
+    background-color: var(--prep-box-bg, var(--canvas-inset, #f2f2f2));
+    border: var(--prep-box-stroke, 1px) solid var(--prep-box-border, var(--border, rgba(128, 128, 128, 0.24)));
+    border-radius: var(--prep-box-radius, 15px);
+    backdrop-filter: blur(var(--prep-box-blur, 0px));
+    -webkit-backdrop-filter: blur(var(--prep-box-blur, 0px));
 }
 .prep-widget-empty {
     flex: 1;


### PR DESCRIPTION
Fixes an issue where the Prep Station widget lacked "Sync with Widget Color and Effect" controls, leaving it stuck with heavy blur and opacity.
Also fixes an issue with the Stats Widgets double-applying the alpha transparency when attempting to sync with global styling.

---
*PR created automatically by Jules for task [1112962923524850213](https://jules.google.com/task/1112962923524850213) started by @h0tp-ftw*